### PR TITLE
Fixes an issue with CentOS 6.6 with PHP 5.3.3 in which using a passed…

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -163,7 +163,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
       $constrained_results = array_intersect_key($solr_results_doc, $solr_fields);
 
       foreach ($constrained_results as $solr_field => $value) {
-        $get_display_value = function ($original_value) use ($solr_field, $solr_fields) {
+        $get_display_value = function ($original_value) use ($solr_field, &$solr_fields) {
           $value = $original_value;
           $field_config = $solr_fields[$solr_field] + array(
             'hyperlink' => 0,

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -163,6 +163,10 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
       $constrained_results = array_intersect_key($solr_results_doc, $solr_fields);
 
       foreach ($constrained_results as $solr_field => $value) {
+        // XXX. Need to pass $solr_fields by reference here even though it's not
+        // modified to get around a bug in PHP 5.3.3 when used on CentOS 6.6,
+        // otherwise the calling function doesn't maintain a reference to the
+        // original value and it becomes a copy.
         $get_display_value = function ($original_value) use ($solr_field, &$solr_fields) {
           $value = $original_value;
           $field_config = $solr_fields[$solr_field] + array(


### PR DESCRIPTION
… by reference paramter in an anonymous function without passing by reference causes the parameter to no longer be modifyable by reference.
