### PR TITLE
Address ISLANDORA-1425

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -178,7 +178,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
           foreach ($value as &$search_value) {
             $solr_query = format_string('!field:"!value"', array(
               '!field' => $solr_field,
-              '!value' => urlencode(islandora_solr_replace_slashes(islandora_solr_lesser_escape($search_value))),
+              '!value' => islandora_solr_replace_slashes(islandora_solr_lesser_escape(rawurlencode($original_value))),
             ));
             $search_value = l($search_value, "islandora/search/$solr_query");
           }


### PR DESCRIPTION
Changed encoding precedence to allow PHP's urlencoding functions to have first dibs at encoding space characters.

PHP's urlencode() function encodes space character as + (plus sign) and islandora_solr_replace_slashes() encodes plus sign in a completely different way...

So I switched to PHP's rawurlencode() function, which encodes space characters as %20, and islandora_solr_replace_slashes() has no effect on %20.

Solution tests very well.

encoded value before: North%255C%2BCarolina%255C-%255C-Charlotte

encoded value after: North%2520Carolina%5C-%5C-Charlotte

There is still an errant and strange "25" showing up in the mix, but this is a great step in the right direction, because search facet links work after this change.

desired result: North%20Carolina%5C-%5C-Charlotte
