### PR TITLE
Add alter before theme call.

### DIFF
--- a/islandora_solr_metadata.api.php
+++ b/islandora_solr_metadata.api.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @file
+ * Hook descriptions.
+ */
+
+/**
+ * Display element alter.
+ *
+ * @param array $elements
+ *   The associative array of parameters as used by the
+ *   'islandora_solr_metadata_display' element, including:
+ *   - islandora_object: The object for which the display is being rendered.
+ *   - print: A boolean flag indicating if the display is to be rendered in a
+ *     printer-friendly manner.
+ *   - associations: An array of metadata configuration IDs, similar to the
+ *     return of islandora_solr_metadata_get_associations_by_cmodels().
+ */
+function hook_islandora_solr_metadata_display_elements_alter(&$elements) {
+  // Artificial example: Get rid of associations if the object is not active.
+  if ($elements['islandora_object']->state != 'A') {
+    $elements['associations'] = array();
+  }
+}
+
+/**
+ * Description element alter.
+ *
+ * @param array $elements
+ *   The associative array of parameters as used by the
+ *   'islandora_solr_metadata_display' element, including:
+ *   - islandora_object: The object for which the display is being rendered.
+ *   - associations: An array of metadata configuration IDs, similar to the
+ *     return of islandora_solr_metadata_get_associations_by_cmodels().
+ */
+function hook_islandora_solr_metadata_description_elements_alter(&$elements) {
+  // Artificial example: Get rid of associations if the object is not active.
+  if ($elements['islandora_object']->state != 'A') {
+    $elements['associations'] = array();
+  }
+}

--- a/islandora_solr_metadata.module
+++ b/islandora_solr_metadata.module
@@ -228,13 +228,13 @@ function islandora_solr_metadata_islandora_metadata_display_info() {
  */
 function islandora_solr_metadata_display_callback(AbstractObject $object, $print = FALSE) {
   module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
-  $associations = islandora_solr_metadata_get_associations_by_cmodels($object->models);
-  if (count($associations) > 0) {
-    $elements = array(
-      'islandora_object' => $object,
-      'print' => $print,
-      'associations' => $associations,
-    );
+  $elements = array(
+    'islandora_object' => $object,
+    'print' => $print,
+    'associations' => islandora_solr_metadata_get_associations_by_cmodels($object->models),
+  );
+  drupal_alter('islandora_solr_metadata_display_elements', $elements);
+  if (count($elements['associations']) > 0) {
     return theme('islandora_solr_metadata_display', $elements);
   }
   else {
@@ -253,12 +253,12 @@ function islandora_solr_metadata_display_callback(AbstractObject $object, $print
  */
 function islandora_solr_metadata_description_callback(AbstractObject $object) {
   module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
-  $associations = islandora_solr_metadata_get_associations_by_cmodels($object->models);
-  if (count($associations) > 0) {
-    $elements = array(
-      'islandora_object' => $object,
-      'associations' => $associations,
-    );
+  $elements = array(
+    'islandora_object' => $object,
+    'associations' => islandora_solr_metadata_get_associations_by_cmodels($object->models),
+  );
+  drupal_alter('islandora_solr_metadata_description_elements', $elements);
+  if (count($elements['associations']) > 0) {
     return theme('islandora_solr_metadata_description', $elements);
   }
   else {


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1566
# What does this Pull Request do?

This pull request introduces calls using `drupal_alter()` before the relevant `theme()` calls. 
# How should this be tested?
1. Without implementations of the new alters, things should continue to function as-is.
2. Implementing the alters, and:
   1. Adding an existing config ID to the `associations` should cause the fields in the specified configuration to be combined into the metadata display.
   2. Setting the `associations` to an array containing a single configuration ID should cause it to be the only display used (excepting other implementations of the alter)

This list is by no means exhaustive: Altering the other parameters (such as `islandora_object` and `print`) should similarly behave according to the current functionality.
# Background context:

Need to adjust the associations based on object content, ideally without introducing additional dependencies (such as (islandora_)context).
# Additional Notes:
- **Does this change require documentation to be updated?** `islandora_solr_metadata.api.php` has been created/updated to contain the new hooks.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** Directly? Unlikely. @mjordan's `islandora_context` Solr metadata plugins might be made to use the new alters instead of using new `theme()` calls. 

**Tagging:** @jordandukart (as maintainer) 

---

Adam Vessey
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
