### PR TITLE
Fix islandora_solr_search module name

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -254,7 +254,7 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
  */
 function islandora_solr_metadata_config_form_validate($form, $form_state) {
   if ($form_state['triggering_element']['#name'] == 'islandora-solr-metadata-add-field') {
-    module_load_include('inc', 'islandora_solr_search', 'includes/luke');
+    module_load_include('inc', 'islandora_solr', 'includes/luke');
     $solr_luke = islandora_solr_get_luke();
     $luke_fields = array_keys($solr_luke['fields']);
 
@@ -299,7 +299,7 @@ function islandora_solr_metadata_config_form_validate($form, $form_state) {
   if ($form_state['triggering_element']['#value'] == 'Save configuration') {
     $solr_field = $form_state['values']['islandora_solr_metadata_fields']['description_fieldset']['available_solr_fields'];
     if (!empty($solr_field)) {
-      module_load_include('inc', 'islandora_solr_search', 'includes/luke');
+      module_load_include('inc', 'islandora_solr', 'includes/luke');
       $solr_luke = islandora_solr_get_luke();
       $luke_fields = array_keys($solr_luke['fields']);
       if (!in_array($solr_field, $luke_fields)) {


### PR DESCRIPTION
**JIRA Ticket**:
- [Incorrect module_load_include calls for files in islandora_solr module](https://jira.duraspace.org/browse/ISLANDORA-1770)
- [Drupal 7.5 missing module warning (related)](https://jira.duraspace.org/browse/ISLANDORA-1757)
- [How to fix "The following module is missing from the file system..." warning messages](https://www.drupal.org/node/2487215)
# What does this Pull Request do?

Upgrading to Drupal 7.5 adds a php warning if there are issues locating modules or themes in the file system.

`User warning: The following module is missing from the file system: islandora_solr_search. In order to fix this, put the module back in its original location. For more information, see the documentation page. in _drupal_trigger_error_with_delayed_logging() (line 1128 of /var/www/html/drupal7/includes/bootstrap.inc).`

Grep identified two modules which had incorrect module name for module_load_include():
- islandora_solr_metadata
- islandora_solution_pack_entities

This PR corrects the module name.
