### PR TITLE
field replacement for URI/PIDs

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -512,6 +512,13 @@ function islandora_solr_metadata_config_field_form($form, &$form_state, $config_
     '#description' => t('Should each value for this field be linked to a search to find objects with the value in this field?'),
     '#default_value' => $get_default('hyperlink', FALSE),
   );
+  $set['uri_replacement'] = array(
+    '#type' => 'textfield',
+    '#title' => t('URI/PID Replacement Field'),
+    '#description' => t('If the value of this field represents a Fedora URI or PID, a Solr field can be specified to replace that value, e.g., with the object label instead of the full URI.'),
+    '#default_value' => $get_default('uri_replacement', ''),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+  );
   // Add in truncation fields for metadata field.
   $truncation_config = array(
     'default_values' => array(

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -206,6 +206,24 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
             'hyperlink' => 0,
             'formatter' => NULL,
           );
+          // Replace URI or PID with a configured field.
+          if (!empty($field_config['uri_replacement'])) {
+            module_load_include('inc', 'islandora', 'includes/utilities');
+            $pid = str_replace('info:fedora/', '', $value);
+            if (islandora_is_valid_pid($pid)) {
+              $relation_qp = new IslandoraSolrQueryProcessor();
+              $relation_qp->solrQuery = 'PID:"' . $pid . '"';
+              $relation_qp->solrParams['fl'] = "PID,{$field_config['uri_replacement']}";
+              $relation_qp->solrLimit = 1;
+              $relation_qp->executeQuery(FALSE);
+              if ($relation_qp->islandoraSolrResult['response']['numFound'] > 0) {
+                $relation_doc = $relation_qp->islandoraSolrResult['response']['objects'][0]['solr_doc'];
+                if (isset($relation_doc[$field_config['uri_replacement']])) {
+                  $value = $relation_doc[$field_config['uri_replacement']];
+                }
+              }
+            }
+          }
           if (($truncation = drupal_array_get_nested_value($field_config, array('truncation'))) && $truncation['max_length'] > 0 && (!isset($truncation['truncation_type']) || $truncation['truncation_type'] == 'separate_value_option')) {
             $value = truncate_utf8($value, $truncation['max_length'], $truncation['word_safe'], $truncation['ellipsis'], $truncation['min_wordsafe_length']);
             if ($value !== $original_value) {

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -205,6 +205,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
           $field_config = $solr_fields[$solr_field] + array(
             'hyperlink' => 0,
             'formatter' => NULL,
+            'uri_replacement' => '',
           );
           // Replace URI or PID with a configured field.
           if (!empty($field_config['uri_replacement'])) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1697
# What does this Pull Request do?

Allows one to replace the value of fields in results, if the value represents a Fedora object, with a field from that object's Solr doc.
# What's new?

A new Solr Luke autocomplete field on field config forms allowing for the input of a secondary field to display on the related object

As well as new functionality to display the contents of that related object's field
# How should this be tested?

Existing fields should function as they did before

URI type fields should display the related object field contents only if they are filled out.
# Interested parties

Can't find Brandon Weigel's GitHub handle on here, so deferring to @jordandukart as the maintainer.
