### PR TITLE
labels in display fields table

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -439,6 +439,7 @@ function islandora_solr_metadata_management($data) {
           '#default_value' => isset($field['remove']) ? $field['remove'] : FALSE,
         ),
         'solr_field_markup' => array('#markup' => filter_xss($field['solr_field'])),
+        'label' => array('#markup' => empty($field['display_label']) ? filter_xss($field['solr_field']) : filter_xss($field['display_label'])),
         'operations' => array(
           'edit' => array(
             '#access' => isset($field['ajax-volatile']) ? !$field['ajax-volatile'] : TRUE,
@@ -466,6 +467,7 @@ function islandora_solr_metadata_management($data) {
     '#header' => array(
       t('Remove'),
       t('Solr Field'),
+      t('Label'),
       t('Operations'),
       '',
     ),

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -18,6 +18,7 @@ function theme_islandora_solr_metadata_management_table(array $variables) {
       'data' => array(
         drupal_render($row['remove_field']),
         drupal_render($row['solr_field_markup']),
+        drupal_render($row['label']),
         drupal_render($row['operations']),
         drupal_render($row['weight']),
       ),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1871

# What does this Pull Request do?

Adds a 'Label' column to the "Display Fields" table for metadata display configuration forms.

# What's new?

A 'Label' column is now in the "Display Fields" table for metadata display configuration forms. This shows the display label if it exists, or the name of the Solr field being used if there is no display label (this would be the default display label).

# How should this be tested?

* Create a metadata display that uses fields with labels and fields without labels
* Observe that the behaviour of the 'Label' column is as described above.

# Additional Notes:
This is a pretty nominal change; shouldn't really affect anything.

# Interested parties
@jordandukart maintains this lovely module, though we'll need someone else to review too
