### PR TITLE
7.x islandora 1872 - Allow custom value separator for Solr

### DIFF
--- a/includes/general.admin.inc
+++ b/includes/general.admin.inc
@@ -27,9 +27,8 @@ function islandora_solr_metadata_general_admin_form($form, &$form_state) {
     'islandora_solr_metadata_field_value_separator' => array(
       '#type' => 'textfield',
       '#title' => t('Field value separator'),
-      '#description' => t('Characters to separate values in multivalued fields.'),
+      '#description' => t('Characters to separate values in multivalued fields. If left empty it will default to newline.'),
       '#default_value' => variable_get('islandora_solr_metadata_field_value_separator', "\n"),
-      '#required' => TRUE,
     ),
     'actions' => array(
       '#type' => 'actions',

--- a/includes/general.admin.inc
+++ b/includes/general.admin.inc
@@ -24,6 +24,12 @@ function islandora_solr_metadata_general_admin_form($form, &$form_state) {
       '#description' => t('Only show unique values from each field. NOTE: Uniqueness is checked on values directly out of Solr. Later formatting of the value could break uniqueness.'),
       '#default_value' => variable_get('islandora_solr_metadata_dedup_values', FALSE),
     ),
+    'islandora_solr_metadata_field_value_separator' => array(
+      '#type' => 'textfield',
+      '#title' => t('Field value separator'),
+      '#description' => t('Characters to separate values in multivalued fields.'),
+      '#default_value' => variable_get('islandora_solr_metadata_field_value_separator', ''),
+    ),
     'actions' => array(
       '#type' => 'actions',
       'submit' => array(
@@ -43,6 +49,7 @@ function islandora_solr_metadata_general_admin_form_submit(&$form, &$form_state)
   $variables = array(
     'islandora_solr_metadata_omit_empty_values',
     'islandora_solr_metadata_dedup_values',
+    'islandora_solr_metadata_field_value_separator',
   );
 
   foreach ($variables as $variable) {

--- a/includes/general.admin.inc
+++ b/includes/general.admin.inc
@@ -43,15 +43,6 @@ function islandora_solr_metadata_general_admin_form($form, &$form_state) {
 }
 
 /**
- * Validation handler for general config form.
- */
-function islandora_solr_metadata_general_admin_form_validate(&$form, &$form_state) {
-  if (empty($form_state['values']['islandora_solr_metadata_field_value_separator'])) {
-    $form_state['values']['islandora_solr_metadata_field_value_separator'] = NULL;
-  }
-}
-
-/**
  * Submission handler for general config form.
  */
 function islandora_solr_metadata_general_admin_form_submit(&$form, &$form_state) {

--- a/includes/general.admin.inc
+++ b/includes/general.admin.inc
@@ -45,7 +45,7 @@ function islandora_solr_metadata_general_admin_form($form, &$form_state) {
 /**
  * Validation handler for general config form.
  */
-function islandora_solr_metadata_general_admin_form_validate(&$form, &$form_state) { 
+function islandora_solr_metadata_general_admin_form_validate(&$form, &$form_state) {
   if (empty($form_state['values']['islandora_solr_metadata_field_value_separator'])) {
     $form_state['values']['islandora_solr_metadata_field_value_separator'] = NULL;
   }

--- a/includes/general.admin.inc
+++ b/includes/general.admin.inc
@@ -28,7 +28,8 @@ function islandora_solr_metadata_general_admin_form($form, &$form_state) {
       '#type' => 'textfield',
       '#title' => t('Field value separator'),
       '#description' => t('Characters to separate values in multivalued fields.'),
-      '#default_value' => variable_get('islandora_solr_metadata_field_value_separator', ''),
+      '#default_value' => variable_get('islandora_solr_metadata_field_value_separator', "\n"),
+      '#required' => TRUE,
     ),
     'actions' => array(
       '#type' => 'actions',

--- a/includes/general.admin.inc
+++ b/includes/general.admin.inc
@@ -43,6 +43,15 @@ function islandora_solr_metadata_general_admin_form($form, &$form_state) {
 }
 
 /**
+ * Validation handler for general config form.
+ */
+function islandora_solr_metadata_general_admin_form_validate(&$form, &$form_state) { 
+  if (empty($form_state['values']['islandora_solr_metadata_field_value_separator'])) {
+    $form_state['values']['islandora_solr_metadata_field_value_separator'] = NULL;
+  }
+}
+
+/**
  * Submission handler for general config form.
  */
 function islandora_solr_metadata_general_admin_form_submit(&$form, &$form_state) {

--- a/islandora_solr_metadata.install
+++ b/islandora_solr_metadata.install
@@ -111,6 +111,7 @@ function islandora_solr_metadata_uninstall() {
   $variables = array(
     'islandora_solr_metadata_omit_empty_values',
     'islandora_solr_metadata_dedup_values',
+    'islandora_solr_metadata_field_value_separator',
   );
   array_walk($variables, 'variable_del');
 }

--- a/theme/islandora-solr-metadata-description.tpl.php
+++ b/theme/islandora-solr-metadata-description.tpl.php
@@ -21,12 +21,12 @@
         print ($desc_array['display_label']); ?>
         <?php endif; ?></h2>
       <?php foreach($description as $value): ?>
-        <p property="description"><?php print check_markup(implode(variable_get('islandora_solr_metadata_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
+        <p property="description"><?php print check_markup(implode($variables['separator'], $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
       <?php endforeach; ?>
     <?php else: ?>
       <?php foreach ($description as $value): ?>
         <h2><?php print $value['display_label']; ?></h2>
-        <p><?php print check_markup(implode(variable_get('islandora_solr_metadata_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
+        <p><?php print check_markup(implode($variables['separator'], $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
       <?php endforeach; ?>
     <?php endif; ?>
   </div>

--- a/theme/islandora-solr-metadata-description.tpl.php
+++ b/theme/islandora-solr-metadata-description.tpl.php
@@ -21,12 +21,12 @@
         print ($desc_array['display_label']); ?>
         <?php endif; ?></h2>
       <?php foreach($description as $value): ?>
-        <p property="description"><?php print check_markup(implode(variable_get('islandora_solr_search_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
+        <p property="description"><?php print check_markup(implode(variable_get('islandora_solr_metadata_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
       <?php endforeach; ?>
     <?php else: ?>
       <?php foreach ($description as $value): ?>
         <h2><?php print $value['display_label']; ?></h2>
-        <p><?php print check_markup(implode(variable_get('islandora_solr_search_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
+        <p><?php print check_markup(implode(variable_get('islandora_solr_metadata_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
       <?php endforeach; ?>
     <?php endif; ?>
   </div>

--- a/theme/islandora-solr-metadata-description.tpl.php
+++ b/theme/islandora-solr-metadata-description.tpl.php
@@ -21,12 +21,12 @@
         print ($desc_array['display_label']); ?>
         <?php endif; ?></h2>
       <?php foreach($description as $value): ?>
-        <p property="description"><?php print check_markup(implode("\n", $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
+        <p property="description"><?php print check_markup(implode(variable_get('islandora_solr_search_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
       <?php endforeach; ?>
     <?php else: ?>
       <?php foreach ($description as $value): ?>
         <h2><?php print $value['display_label']; ?></h2>
-        <p><?php print check_markup(implode("\n", $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
+        <p><?php print check_markup(implode(variable_get('islandora_solr_search_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?></p>
       <?php endforeach; ?>
     <?php endif; ?>
   </div>

--- a/theme/islandora-solr-metadata-display.tpl.php
+++ b/theme/islandora-solr-metadata-display.tpl.php
@@ -30,7 +30,7 @@
           <?php print $value['display_label']; ?>
         </dt>
         <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
-          <?php print check_markup(implode(variable_get('islandora_solr_metadata_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
+          <?php print check_markup(implode($variables['separator'], $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
         </dd>
         <?php $row_field++; ?>
       <?php endforeach; ?>

--- a/theme/islandora-solr-metadata-display.tpl.php
+++ b/theme/islandora-solr-metadata-display.tpl.php
@@ -30,7 +30,7 @@
           <?php print $value['display_label']; ?>
         </dt>
         <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
-          <?php print check_markup(implode("\n", $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
+          <?php print check_markup(implode(variable_get('islandora_solr_search_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
         </dd>
         <?php $row_field++; ?>
       <?php endforeach; ?>

--- a/theme/islandora-solr-metadata-display.tpl.php
+++ b/theme/islandora-solr-metadata-display.tpl.php
@@ -30,7 +30,7 @@
           <?php print $value['display_label']; ?>
         </dt>
         <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
-          <?php print check_markup(implode(variable_get('islandora_solr_search_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
+          <?php print check_markup(implode(variable_get('islandora_solr_metadata_field_value_separator', "\n"), $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
         </dd>
         <?php $row_field++; ?>
       <?php endforeach; ?>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -142,7 +142,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
             $field['description_data']['truncation']['ellipsis'],
             $field['description_data']['truncation']['word_safe'],
             $field['description_data']['truncation']['min_wordsafe_length'],
-            "\n"
+            variable_get('islandora_solr_search_field_value_separator', "\n")
           );
           $field['value'] = $updated_value;
         }
@@ -154,7 +154,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
               $field['description_data']['truncation']['ellipsis'],
               $field['description_data']['truncation']['word_safe'],
               $field['description_data']['truncation']['min_wordsafe_length'],
-              " "
+              variable_get('islandora_solr_search_field_value_separator', ' ')
             );
           }
         }
@@ -302,7 +302,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
         // Check if the field is configured to filter based on whole field.
         if (($truncation = drupal_array_get_nested_value($field, array('truncation'))) && $truncation['max_length'] > 0 && isset($truncation['truncation_type']) && $truncation['truncation_type'] == 'whole_field_option') {
           // Keep the updated value stored in an array.
-          $updated_value[] = islandora_solr_truncate_field_display($field['value'], $truncation['max_length'], $truncation['ellipsis'], $truncation['word_safe'], $truncation['min_wordsafe_length'], "\n");
+          $updated_value[] = islandora_solr_truncate_field_display($field['value'], $truncation['max_length'], $truncation['ellipsis'], $truncation['word_safe'], $truncation['min_wordsafe_length'], variable_get('islandora_solr_search_field_value_separator', '\n'));
           // Replace value with updated field display.
           $field['value'] = $updated_value;
         }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -138,6 +138,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
         if ($field['description_data']['truncation']['truncation_type'] == 'whole_field_option') {
           $updated_value[] = islandora_solr_truncate_field_display(
             $field['value'],
+            "Brandon",
             $field['description_data']['truncation']['max_length'],
             $field['description_data']['truncation']['ellipsis'],
             $field['description_data']['truncation']['word_safe'],

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -142,7 +142,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
             $field['description_data']['truncation']['ellipsis'],
             $field['description_data']['truncation']['word_safe'],
             $field['description_data']['truncation']['min_wordsafe_length'],
-            variable_get('islandora_solr_search_field_value_separator', "\n")
+            variable_get('islandora_solr_metadata_field_value_separator', "\n")
           );
           $field['value'] = $updated_value;
         }
@@ -154,7 +154,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
               $field['description_data']['truncation']['ellipsis'],
               $field['description_data']['truncation']['word_safe'],
               $field['description_data']['truncation']['min_wordsafe_length'],
-              variable_get('islandora_solr_search_field_value_separator', ' ')
+              variable_get('islandora_solr_metadata_field_value_separator', ' ')
             );
           }
         }
@@ -302,7 +302,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
         // Check if the field is configured to filter based on whole field.
         if (($truncation = drupal_array_get_nested_value($field, array('truncation'))) && $truncation['max_length'] > 0 && isset($truncation['truncation_type']) && $truncation['truncation_type'] == 'whole_field_option') {
           // Keep the updated value stored in an array.
-          $updated_value[] = islandora_solr_truncate_field_display($field['value'], $truncation['max_length'], $truncation['ellipsis'], $truncation['word_safe'], $truncation['min_wordsafe_length'], variable_get('islandora_solr_search_field_value_separator', '\n'));
+          $updated_value[] = islandora_solr_truncate_field_display($field['value'], $truncation['max_length'], $truncation['ellipsis'], $truncation['word_safe'], $truncation['min_wordsafe_length'], variable_get('islandora_solr_metadata_field_value_separator', "\n"));
           // Replace value with updated field display.
           $field['value'] = $updated_value;
         }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -131,7 +131,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
   // XXX: Seems a little odd, yes... Was reusing the "description" value,
   // though.
   $variables['description'] = $variables['solr_fields'];
-  $separator = variable_get('islandora_solr_search_field_value_separator', "\n");
+  $separator = variable_get('islandora_solr_metadata_field_value_separator', "\n");
   // Truncate the description value(s).
   foreach ($variables['description'] as &$field) {
     if (isset($field['description_data']['truncation'])) {

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -157,7 +157,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
               $field['description_data']['truncation']['ellipsis'],
               $field['description_data']['truncation']['word_safe'],
               $field['description_data']['truncation']['min_wordsafe_length'],
-              $separator
+              " "
             );
           }
         }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -74,6 +74,10 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
   }
 
   $variables['parent_collections'] = islandora_get_parents_from_rels_ext($object);
+  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', '');
+  if (empty($variables['separator'])) {
+    $variables['separator'] = "\n";
+  }
 }
 
 /**
@@ -118,6 +122,10 @@ function template_preprocess_islandora_solr_metadata_description(array &$variabl
       'description_data' => $description['description_data'],
     );
   }
+  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', '');
+  if (empty($variables['separator'])) {
+    $variables['separator'] = "\n";
+  }
 }
 
 /**
@@ -136,18 +144,25 @@ function template_process_islandora_solr_metadata_description(array &$variables)
         module_load_include('inc', 'islandora_solr', 'includes/utilities');
         $field['value'] = array_filter($field['value']);
         if ($field['description_data']['truncation']['truncation_type'] == 'whole_field_option') {
+          $separator = variable_get('islandora_solr_search_field_value_separator', '');
+          if (empty($separator)) {
+            $separator = "\n";
+          }
           $updated_value[] = islandora_solr_truncate_field_display(
             $field['value'],
-            "Brandon",
             $field['description_data']['truncation']['max_length'],
             $field['description_data']['truncation']['ellipsis'],
             $field['description_data']['truncation']['word_safe'],
             $field['description_data']['truncation']['min_wordsafe_length'],
-            variable_get('islandora_solr_metadata_field_value_separator', "\n")
+            $separator
           );
           $field['value'] = $updated_value;
         }
         else {
+          $separator = variable_get('islandora_solr_search_field_value_separator', '');
+          if (empty($separator)) {
+            $separator = ' ';
+          }
           foreach ($field['value'] as $index => $value) {
             $field['value'][$index] = islandora_solr_truncate_field_display(
               (array) $value,
@@ -155,7 +170,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
               $field['description_data']['truncation']['ellipsis'],
               $field['description_data']['truncation']['word_safe'],
               $field['description_data']['truncation']['min_wordsafe_length'],
-              variable_get('islandora_solr_metadata_field_value_separator', ' ')
+              $separator
             );
           }
         }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -74,10 +74,7 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
   }
 
   $variables['parent_collections'] = islandora_get_parents_from_rels_ext($object);
-  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', '');
-  if (empty($variables['separator'])) {
-    $variables['separator'] = "\n";
-  }
+  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', "\n");
 }
 
 /**
@@ -122,10 +119,7 @@ function template_preprocess_islandora_solr_metadata_description(array &$variabl
       'description_data' => $description['description_data'],
     );
   }
-  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', '');
-  if (empty($variables['separator'])) {
-    $variables['separator'] = "\n";
-  }
+  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', "\n");
 }
 
 /**
@@ -137,6 +131,7 @@ function template_process_islandora_solr_metadata_description(array &$variables)
   // XXX: Seems a little odd, yes... Was reusing the "description" value,
   // though.
   $variables['description'] = $variables['solr_fields'];
+  $separator = variable_get('islandora_solr_search_field_value_separator', "\n");
   // Truncate the description value(s).
   foreach ($variables['description'] as &$field) {
     if (isset($field['description_data']['truncation'])) {
@@ -144,10 +139,6 @@ function template_process_islandora_solr_metadata_description(array &$variables)
         module_load_include('inc', 'islandora_solr', 'includes/utilities');
         $field['value'] = array_filter($field['value']);
         if ($field['description_data']['truncation']['truncation_type'] == 'whole_field_option') {
-          $separator = variable_get('islandora_solr_search_field_value_separator', '');
-          if (empty($separator)) {
-            $separator = "\n";
-          }
           $updated_value[] = islandora_solr_truncate_field_display(
             $field['value'],
             $field['description_data']['truncation']['max_length'],
@@ -159,10 +150,6 @@ function template_process_islandora_solr_metadata_description(array &$variables)
           $field['value'] = $updated_value;
         }
         else {
-          $separator = variable_get('islandora_solr_search_field_value_separator', '');
-          if (empty($separator)) {
-            $separator = ' ';
-          }
           foreach ($field['value'] as $index => $value) {
             $field['value'][$index] = islandora_solr_truncate_field_display(
               (array) $value,

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -72,9 +72,13 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
       'value' => array(),
     );
   }
+  $separator = variable_get('islandora_solr_metadata_field_value_separator', "\n");
 
+  if (empty($separator)) {
+    $separator = "\n";
+  }
+  $variables['separator'] = $separator;
   $variables['parent_collections'] = islandora_get_parents_from_rels_ext($object);
-  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', "\n");
 }
 
 /**
@@ -119,7 +123,12 @@ function template_preprocess_islandora_solr_metadata_description(array &$variabl
       'description_data' => $description['description_data'],
     );
   }
-  $variables['separator'] = variable_get('islandora_solr_metadata_field_value_separator', "\n");
+  $separator = variable_get('islandora_solr_metadata_field_value_separator', "\n");
+
+  if (empty($separator)) {
+    $separator = "\n";
+  }
+  $variables['separator'] = $separator;
 }
 
 /**
@@ -132,6 +141,10 @@ function template_process_islandora_solr_metadata_description(array &$variables)
   // though.
   $variables['description'] = $variables['solr_fields'];
   $separator = variable_get('islandora_solr_metadata_field_value_separator', "\n");
+
+  if (empty($separator)) {
+    $separator = "\n";
+  }
   // Truncate the description value(s).
   foreach ($variables['description'] as &$field) {
     if (isset($field['description_data']['truncation'])) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1872

# What does this Pull Request do?

This will allow the user to specify a separator between multivalued fields in solr metadata display.

# What's new?

* added new textfield in the general configuration form 'islandora_solr_metadata_field_value_separator'.
* added a check for empty values in the admin form validation handler. This is to prevent users from saving the form and having empty values passed to the display, causing results to look messy.
* the separator usage has been added to islandora-solr-metadata-description.tpl.php & islandora-solr-metadata-display.tpl.php templates.

# How should this be tested?

* Ingest an object and create some multivalued fields (mods_name_personal_creator_namePart_ms for example).
* Navigate to your.site/admin/islandora/search/islandora_solr/metadata and under the 'General Configuration' tab you will see a new field labelled 'Field value separator'.
* Enter test values, and also test that empty values are being set to NULL and falling back to default separators.
* Make sure your multivalued field is in a solr metadata display configuration.

# Interested parties
@Islandora/7-x-1-x-committers, @nhart