### PR TITLE
Adding #delta to the metadata fields tableselect weight array

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -429,7 +429,7 @@ function islandora_solr_metadata_management($data) {
   if ($data) {
     uasort($data, 'drupal_sort_weight');
     $delta = count($data);
-    $weight = 1;
+    $weight = 0;
     $map = function ($field) use ($delta, &$weight) {
       $value = $weight;
       $weight++;
@@ -454,6 +454,7 @@ function islandora_solr_metadata_management($data) {
         ),
         'weight' => array(
           '#type' => 'weight',
+          '#delta' => $delta >= 10 ? $delta : 10,
           '#default_value' => $weight,
         ),
       );

--- a/includes/config.inc
+++ b/includes/config.inc
@@ -428,9 +428,9 @@ function islandora_solr_metadata_management($data) {
 
   if ($data) {
     uasort($data, 'drupal_sort_weight');
-    $delta = count($data);
+    $max_delta = max(count($data), 10);
     $weight = 0;
-    $map = function ($field) use ($delta, &$weight) {
+    $map = function ($field) use ($max_delta, &$weight) {
       $value = $weight;
       $weight++;
       return array(
@@ -454,7 +454,7 @@ function islandora_solr_metadata_management($data) {
         ),
         'weight' => array(
           '#type' => 'weight',
-          '#delta' => $delta >= 10 ? $delta : 10,
+          '#delta' => $max_delta,
           '#default_value' => $weight,
         ),
       );


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1952)

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
Additional related JIRA ticket: [ISLANDORA-1903](https://jira.duraspace.org/browse/ISLANDORA-1903)
# What does this Pull Request do?
When adding more than 20 rows to an islandora solr metadata configuration, the table select will stop maintaining weights, preventing users from saving an adjusted fields weight . This appears to relate to [a previous JIRA ticket](https://jira.duraspace.org/browse/ISLANDORA-1903) that allowed row weights to be shown. This ticket implements the row delta to allow these modifications to be saved.

# What's new?
Row weights are now preservable on the tableselect in the islandora_solr_metadata configuration page.

# How should this be tested?
* include this pull request in local code 
* Create an islandora_solr_metadata configuration
* Add 20 ~ 30 fields to the metadata config.
* Try to adjust the last two fields, and save. This should result in erratic behaviour, and the field weights not being saved as desired.

# Interested parties
Tag @Islandora/7-x-1-x-committers

