### PR TITLE
Fixed an issue when when updating i18n_strings, certain operations (a…

### DIFF
--- a/includes/db.inc
+++ b/includes/db.inc
@@ -483,7 +483,9 @@ function islandora_solr_metadata_update_i18n_strings($id, $fields) {
   if (module_exists('i18n_string')) {
     foreach ($fields as $field => $info) {
       $i18n_id = islandora_solr_metadata_field_i18n_id($id, $info['solr_field']);
-      i18n_string_update($i18n_id, $info['display_label']);
+      if (isset($info['display_label'])) {
+        i18n_string_update($i18n_id, $info['display_label']);
+      }
     }
   }
 }


### PR DESCRIPTION
…dd) have a null display_label.

**JIRA Ticket**: (link)

# What does this Pull Request do?

Adding new display fields resulted in a warning "Undefined index: display_label". 

# What's new?
Adding a null check for display label before attempting to update i18n strings.

# How should this be tested?
Reproduce:
    Go to admin/islandora/search/islandora_solr/metadata
    Edit an existing form
    Search for and add a field
    Save the form.
Notice will appear.
Change will remove the noticed when a field is added.
