### PR TITLE
Added option to expand or collapse details on metadata view

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -60,7 +60,7 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
           unset($form_state['complete form']['islandora_solr_metadata_cmodels']['table_wrapper']['table']['#options'][$key]);
         }
       }
-    }
+   }
   }
   $form = array(
     '#tree' => TRUE,
@@ -146,13 +146,20 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
     );
   }
 
+   $form['islandora_solr_metadata_collapse_' . $configuration_id] = array(
+    '#title' => 'Display fields expanded',
+    '#type' => 'checkbox',
+    '#description' => t('Unselect to have details collapsed'),
+    '#default_value' => variable_get('islandora_solr_metadata_collapse_' . $configuration_id, 1),
+
+  );
+
   $form['islandora_solr_metadata_fields'] = array(
     '#type' => 'fieldset',
     '#title' => 'Display fields',
     '#collapsed' => TRUE,
     '#collapsible' => FALSE,
   );
-
   $form['islandora_solr_metadata_fields']['table_wrapper'] = array(
     '#prefix' => '<div id="islandora-solr-metadata-fields-wrapper">',
     '#suffix' => '</div>',
@@ -217,6 +224,8 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
       ),
     ),
   );
+
+  
 
   // Add in truncation fields for description.
   $truncation_config = array(
@@ -320,6 +329,9 @@ function islandora_solr_metadata_config_form_validate($form, $form_state) {
 function islandora_solr_metadata_config_form_submit($form, $form_state) {
   module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
   $configuration_id = $form_state['values']['islandora_solr_metadata_configuration_id'];
+
+  $collapse = $form_state['values']['islandora_solr_metadata_collapse_' . $configuration_id];
+  variable_set('islandora_solr_metadata_collapse_' . $configuration_id, $collapse);
 
   if ($form_state['clicked_button']['#value'] == 'Save configuration') {
     // Grab existing entries first for comparison.

--- a/includes/config.inc
+++ b/includes/config.inc
@@ -60,7 +60,7 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
           unset($form_state['complete form']['islandora_solr_metadata_cmodels']['table_wrapper']['table']['#options'][$key]);
         }
       }
-   }
+    }
   }
   $form = array(
     '#tree' => TRUE,
@@ -145,15 +145,12 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
       ),
     );
   }
-
-   $form['islandora_solr_metadata_collapse_' . $configuration_id] = array(
+  $form['islandora_solr_metadata_collapse_' . $configuration_id] = array(
     '#title' => 'Display fields expanded',
     '#type' => 'checkbox',
     '#description' => t('Unselect to have details collapsed'),
     '#default_value' => variable_get('islandora_solr_metadata_collapse_' . $configuration_id, 1),
-
   );
-
   $form['islandora_solr_metadata_fields'] = array(
     '#type' => 'fieldset',
     '#title' => 'Display fields',
@@ -225,9 +222,7 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
     ),
   );
 
-  
-
-  // Add in truncation fields for description.
+  //Add in truncation fields for description.
   $truncation_config = array(
     'default_values' => array(
       'truncation_type' => $description['description_data']['truncation']['truncation_type'] ? $description['description_data']['truncation']['truncation_type'] : 'separate_value_option',

--- a/theme/islandora-solr-metadata-display.tpl.php
+++ b/theme/islandora-solr-metadata-display.tpl.php
@@ -18,9 +18,10 @@
  * @see template_process_islandora_solr_metadata_display()
  */
 ?>
+
 <?php if ($found):
   if (!(empty($solr_fields) && variable_get('islandora_solr_metadata_omit_empty_values', FALSE))):?>
-<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
+    <fieldset <?php ($print || $variables['not_collapsed']) ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
   <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
   <div class="fieldset-wrapper">
     <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields">
@@ -39,7 +40,7 @@
 </fieldset>
 <?php endif; ?>
 <?php else: ?>
-  <fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
+	<fieldset <?php ($print || $variables['not_collapsed'])? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
     <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
     <?php //XXX: Hack in markup for message. ?>
     <div class="messages--warning messages warning">

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -54,6 +54,8 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
   module_load_include('inc', 'islandora', 'includes/utilities');
   drupal_add_js('misc/form.js');
   drupal_add_js('misc/collapse.js');
+  drupal_add_js(drupal_get_path('module', 'islandora_solr_metadata') . 'js/collapse.js');
+
 
   $object = $variables['islandora_object'];
   $db_fields = array();
@@ -63,7 +65,12 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
   foreach ($associations as $configuration_id) {
     $field = islandora_solr_metadata_get_fields($configuration_id['configuration_id']);
     $db_fields = array_merge($db_fields, $field);
+
+    //Add this variable here because we will not no the configuration_id in the template
+    $collapse_default = variable_get('islandora_solr_metadata_collapse_' . $configuration_id['configuration_id'], 1);
   }
+  $variables['not_collapsed'] = $collapse_default;
+ 
   foreach ($db_fields as $solr_field => $value) {
     if (isset($solr_fields[$solr_field])) {
       continue;

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -56,7 +56,6 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
   drupal_add_js('misc/collapse.js');
   drupal_add_js(drupal_get_path('module', 'islandora_solr_metadata') . 'js/collapse.js');
 
-
   $object = $variables['islandora_object'];
   $db_fields = array();
   $solr_fields =& $variables['solr_fields'];
@@ -66,11 +65,12 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
     $field = islandora_solr_metadata_get_fields($configuration_id['configuration_id']);
     $db_fields = array_merge($db_fields, $field);
 
-    //Add this variable here because we will not no the configuration_id in the template
-    $collapse_default = variable_get('islandora_solr_metadata_collapse_' . $configuration_id['configuration_id'], 1);
+    // Add this variable here because we will not no the configuration_id in the template
+    $collapse_default = variable_get('islandora_solr_metadata_collapse_' 
+      . $configuration_id['configuration_id'], 1);
   }
   $variables['not_collapsed'] = $collapse_default;
- 
+
   foreach ($db_fields as $solr_field => $value) {
     if (isset($solr_fields[$solr_field])) {
       continue;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1252

# What does this Pull Request do?

Added a configuration option that allows users to select the default collapse state of the details metadata

# What's new?
Added a drupal variable to the config form.  Set this value as a template variable.  Check the variable in the template at display time.

# How should this be tested?

Enable and disable details view collapse and check that the behaviour was as expected.

# Additional Notes:
Hope I did this correctly

May want to change documentation to reflect this new option.

# Interested parties
@Islandora/7-x-1-x-committers
