### PR TITLE
adding display_label to the field data of a field added via the ajax …

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -34,6 +34,7 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
       $form_state['field_data'][$field_name] = array(
         'configuration_id' => $configuration_id,
         'solr_field' => $field_name,
+        'display_label' => $field_name,
         // Arbitrary large sort weight so it always comes last.
         'weight' => 10000,
         'ajax-volatile' => TRUE,


### PR DESCRIPTION
…add button.

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2128

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Fixes an error in /admin/islandora/search/islandora_solr_metadata where adding a new field to a configuration via the "Add" button and saving the form would result in an undefined index error.

# What's new?
Added a default display_label to the field data before it is saved and the i18n strings are saved.

# How should this be tested?

To replicate:
    go to admin/islandora/search/islandora_solr/metadata
    edit an existing configuration 
    Use ADD FIELD
    Save

# Interested parties
@Islandora/7-x-1-x-committers
