### PR TITLE
Add a date format per field.

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -523,6 +523,14 @@ function islandora_solr_metadata_config_field_form($form, &$form_state, $config_
     '#default_value' => $get_default('uri_replacement', ''),
     '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
   );
+  if (islandora_solr_is_date_field($field_name)) {
+    $set['date_format'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Date format'),
+      '#default_value' => $get_default('date_format', ''),
+      '#description' => t('The format of the date, as it will be displayed in the search results. Use <a href="!url" target="_blank">PHP date()</a> formatting. Works best when the date format matches the granularity of the source data. Otherwise it is possible that there will be duplicates displayed.', array('!url' => 'http://php.net/manual/function.date.php')),
+    );
+  }
   // Add in truncation fields for metadata field.
   $truncation_config = array(
     'default_values' => array(

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -225,6 +225,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
             'hyperlink' => 0,
             'formatter' => NULL,
             'uri_replacement' => '',
+            'date_format' => '',
           );
           // Replace URI or PID with a configured field.
           if (!empty($field_config['uri_replacement'])) {
@@ -263,7 +264,9 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
               ));
             }
           }
-
+          if (islandora_solr_is_date_field($solr_field) && !empty($solr_fields[$solr_field]['date_format'])) {
+            $value = format_date(strtotime($value), 'custom', $solr_fields[$solr_field]['date_format'], 'UTC');
+          }
           if (is_callable($field_config['formatter'])) {
             $value = call_user_func($field_config['formatter'], $value);
           }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2274
* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?
Adds the ability to specify a human readable date format when rendering date fields within Solr Metadata.

# What's new?
Additional textfield that appears only for date fields that allows the user to enter a date format.

# How should this be tested?
Choose Solr Metadata as the metadata display to be used in Islandora.
Create a Solr metadata configuration
Add a date field
Configure the date field to use a date_format that you specify.
View the object and note that the date field shows the human readable format.

# Additional Notes:
This should likely be tested against a configuration that had a date field previously to ensure there is no regression / unintended behavior.

# Interested parties
@Islandora/7-x-1-x-committers
