### PR TITLE
Don't make unnecessary requests to the luke.

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -264,7 +264,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
               ));
             }
           }
-          if (islandora_solr_is_date_field($solr_field) && !empty($solr_fields[$solr_field]['date_format'])) {
+          if (!empty($solr_fields[$solr_field]['date_format']) && islandora_solr_is_date_field($solr_fields[$solr_field])) {
             $value = format_date(strtotime($value), 'custom', $solr_fields[$solr_field]['date_format'], 'UTC');
           }
           if (is_callable($field_config['formatter'])) {

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -264,7 +264,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
               ));
             }
           }
-          if (!empty($solr_fields[$solr_field]['date_format']) && islandora_solr_is_date_field($solr_fields[$solr_field])) {
+          if (!empty($solr_fields[$solr_field]['date_format']) && islandora_solr_is_date_field($solr_field)) {
             $value = format_date(strtotime($value), 'custom', $solr_fields[$solr_field]['date_format'], 'UTC');
           }
           if (is_callable($field_config['formatter'])) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2381

# What does this Pull Request do?
Reverses the order of the conditional evaluation such that a call out to Solr's luke does not occur unless the user has specified a date format.

# What's new?
Reversing conditions for less requests.

# How should this be tested?
View a metadata display that has fields with and without date_formats, behavior is the exact same as before. Fields without date_formats aren't formatted, fields with are.

# Interested parties
@Islandora/7-x-1-x-committers, @DiegoPino
