### PR TITLE
Fix bug with adding content models

### DIFF
--- a/includes/configurations.features.inc
+++ b/includes/configurations.features.inc
@@ -95,9 +95,7 @@ function islandora_solr_metadata_configurations_features_rebuild($module_name) {
       }
       // Add fields and cmodels, related to config_id.
       islandora_solr_metadata_update_description($config_id, $config_info['description']['description_field'], $config_info['description']['description_label'], $config_info['description']['description_data']);
-      islandora_solr_metadata_add_content_models($config_id, array_map(function ($e) {
-        return array('cmodel' => $e);
-      }, $config_info['cmodels']));
+      islandora_solr_metadata_add_content_models($config_id, $config_info['cmodels']);
       islandora_solr_metadata_add_fields($config_id, $config_info['fields']);
     }
   }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2502](https://jira.lyrasis.org/browse/ISLANDORA-2502)

# What does this Pull Request do?

Fixes a bug when rebuilding features, specifically with the content model associations database table. 

# What's new?

The `islandora_solr_metadata_configurations_features_rebuild` function [is passing an extra layer of array nesting](https://github.com/Islandora/islandora_solr_metadata/blob/7.x/includes/configurations.features.inc#L98) to the function that writes the cmodel associations to the database. So for example, it's passing in

```
array(
	'islandora:sp_basic_image' => array(
    'cmodel' => array(
      'cmodel' => 'islandora:sp_basic_image'
    ),
  ),
  'islandora:sp_pdf' => array(
    'cmodel' => array(
      'cmodel' => 'islandora:sp_pdf',
    ),
  ),
);
```
instead of what the `islandora_solr_metadata_add_content_models` function expects:

```
array(
  'islandora:sp_basic_image' => array(
    'cmodel' => 'islandora:sp_basic_image,
  ),
  'islandora:sp_pdf' => array(
    'cmodel' => 'islandora:sp_pdf',
  ),
);
```

When using PostgreSQL, the code in the [database engine](https://api.drupal.org/api/drupal/includes%21database%21pgsql%21query.inc/class/InsertQuery_pgsql/7.x) makes use of the `bindParams` function to write records to the database, which warns of an "array to string conversion" then simply writes the literal string "Array" to the database.

This change fixes the call to `islandora_solr_metadata_add_content_models` so that the correct entries are written in the database.

# How should this be tested?

Test on an islandora installation that uses PostgreSQL as the database and has islandora_solr_metadata and features modules installed

Steps to reproduce:
- Create a metadata display configuration at admin/islandora/search/islandora_solr/metadata. Make sure to add at least one content model association to the configuration

- Add this metadata display configuration to a feature at /admin/structure/features

- Export the feature to somewhere in your modules directory

- Delete the metadata display configurationRevert the feature with the following drush command:

    `drush -u 1 -vvv fr name_of_my_feature` 

- Observe the "array to string conversion" warning and the value of "Array" for the content model associations of your metadata configuration

With the fix from this PR, follow the above steps and verify that rebuilding the feature adds content model configurations properly.

Repeat the above steps with MySQL and verify that the fix doesn't introduce any regressions.


# Interested parties
@Islandora/7-x-1-x-committers
