### PR TITLE
ISLANDORA-2534; SUP-5934. Resolve PHP warnings when array keys don't exist

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -222,11 +222,11 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
   // Add in truncation fields for description.
   $truncation_config = array(
     'default_values' => array(
-      'truncation_type' => $description['description_data']['truncation']['truncation_type'] ? $description['description_data']['truncation']['truncation_type'] : 'separate_value_option',
-      'max_length' => $description['description_data']['truncation']['max_length'] ? $description['description_data']['truncation']['max_length'] : 0,
-      'word_safe' => $description['description_data']['truncation']['word_safe'] ? $description['description_data']['truncation']['word_safe'] : FALSE,
-      'ellipsis' => $description['description_data']['truncation']['ellipsis'] ? $description['description_data']['truncation']['ellipsis'] : FALSE,
-      'min_wordsafe_length' => $description['description_data']['truncation']['min_wordsafe_length'] ? $description['description_data']['truncation']['min_wordsafe_length'] : 1,
+      'truncation_type' => isset($description['description_data']['truncation']['truncation_type']) ? $description['description_data']['truncation']['truncation_type'] : 'separate_value_option',
+      'max_length' => isset($description['description_data']['truncation']['max_length']) ? $description['description_data']['truncation']['max_length'] : 0,
+      'word_safe' => isset($description['description_data']['truncation']['word_safe']) ? $description['description_data']['truncation']['word_safe'] : FALSE,
+      'ellipsis' => isset($description['description_data']['truncation']['ellipsis']) ? $description['description_data']['truncation']['ellipsis'] : FALSE,
+      'min_wordsafe_length' => isset($description['description_data']['truncation']['min_wordsafe_length']) ? $description['description_data']['truncation']['min_wordsafe_length'] : 1,
     ),
     'min_wordsafe_length_input_path' => "islandora_solr_metadata_fields[description_fieldset][truncation][word_safe]",
   );

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -349,10 +349,12 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
         // Apply rules configurations for this field as configured
         // on the metadata configuration page. Unset the field from
         // the $solr_fields array to prevent it from being shown.
-        $permission = drupal_array_get_nested_value($field, array('permissions'));
-        if ($permission['enable_permissions'] && !array_intersect(array_keys($user->roles), $permission['permissions'])) {
-          // Permissions are being enforced and none of our roles are allowed...
-          unset($solr_fields[$field['solr_field']]);
+	$permission = drupal_array_get_nested_value($field, array('permissions'));
+	if (isset($permission['permissions'])) {
+          if ($permission['enable_permissions'] && !array_intersect(array_keys($user->roles), $permission['permissions'])) {
+            // Permissions are being enforced and none of our roles are allowed...
+            unset($solr_fields[$field['solr_field']]);
+          }
         }
       }
 


### PR DESCRIPTION
**JIRA Ticket**: [(link)](https://islandora-legacy.atlassian.net/browse/ISLANDORA-2534)

# What does this Pull Request do?

Adds checks to verify array key exists before trying to reference it.

# How should this be tested?
Enable Islandora Solr Metadata for display, add a content model and setup fields leaving the description field empty.
View an object that uses the profile set up above.
Verify no errors are thrown


# Interested parties
@patdunlavey  @Islandora/legacy-committers 
